### PR TITLE
fix: enable EKS daemon private registry pulls

### DIFF
--- a/docs/eks-karpenter.md
+++ b/docs/eks-karpenter.md
@@ -1,0 +1,143 @@
+# EKS + Karpenter Test Build and Install
+
+This document is the fast path for testing Hermes on EKS nodes created by
+Karpenter.
+
+The controller runs as a normal Kubernetes Deployment. The node-side
+`hermes-daemon` runs directly on each EC2 worker node as the containerd
+snapshotter gRPC service.
+
+## 1. Build Artifacts in GitHub Actions
+
+Run the `Hermes Build` workflow manually, or push to `main`.
+
+Outputs:
+
+```text
+public.ecr.aws/cloudpilotai/hermes-controller:latest
+hermes-daemon-linux-amd64-tar-gz GitHub Actions artifact
+hermes-daemon-linux-amd64-tar-gz-sha256 GitHub Actions artifact
+```
+
+The image build follows the same pattern as `cloudpilot-agent`: GitHub Actions
+sets `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` from `secrets.AWS_AK` and
+`secrets.AWS_SK`, logs in to ECR Public, then `ko build --bare` pushes the
+controller image to `KO_DOCKER_REPO=public.ecr.aws/cloudpilotai/hermes-controller`.
+
+The ECR Public repository must already exist before the workflow runs. GitHub
+Actions downloads artifacts as zip files, so extract `hermes-daemon-linux-amd64.tar.gz`
+from `hermes-daemon-linux-amd64-tar-gz` and publish the tarball itself to a URL
+that new EC2 nodes can read, such as an S3 presigned URL. Pass that tarball URL
+as `HERMES_DAEMON_URL` when installing the node daemon. If you want checksum
+verification, extract `hermes-daemon-linux-amd64.tar.gz.sha256` from
+`hermes-daemon-linux-amd64-tar-gz-sha256` and pass its contents as
+`HERMES_DAEMON_SHA256`; it must be the raw 64-character digest.
+
+## 2. Deploy the Controller
+
+```bash
+export HERMES_CONTROLLER_IMAGE=public.ecr.aws/cloudpilotai/hermes-controller:latest
+
+kubectl apply -f deploy/hermespolicy-crd.yaml
+
+sed "s|ghcr.io/example/hermes-controller:latest|${HERMES_CONTROLLER_IMAGE}|" \
+  deploy/hermes-controller.yaml | kubectl apply -f -
+
+kubectl -n hermes-system rollout status deploy/hermes-controller
+kubectl -n hermes-system get svc hermes-controller -o wide
+```
+
+The default Service is a NodePort backing object:
+
+```text
+hermes-controller hermes-system 39091:30080/TCP
+```
+
+The node daemon defaults to `HERMES_ENDPOINT=auto-nodeport`, which reads the EC2
+node primary IP from IMDS and uses `http://<node-ip>:30080`.
+
+## 3. Install the Node gRPC Snapshotter Through Karpenter
+
+Add the install command to the Karpenter `EC2NodeClass` user data. Keep both
+URLs in quoted variables; S3 presigned URLs contain `&`, which the shell will
+otherwise split into background commands.
+
+```yaml
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: hermes-al2023
+spec:
+  amiFamily: AL2023
+  userData: |
+    #!/bin/bash
+    set -euxo pipefail
+
+    export HERMES_INSTALLER_URL="https://raw.githubusercontent.com/cloudpilot-ai/hermes/main/hack/eks/install-hermes-daemon.sh"
+    export HERMES_DAEMON_URL="<https-url-to-hermes-daemon-linux-amd64.tar.gz>"
+    export HERMES_DAEMON_SHA256="<raw-64-character-sha256>"
+
+    curl -fsSL "${HERMES_INSTALLER_URL}" | \
+      HERMES_DAEMON_URL="${HERMES_DAEMON_URL}" \
+      HERMES_DAEMON_SHA256="${HERMES_DAEMON_SHA256}" \
+      bash -s --
+```
+
+The installer writes:
+
+```text
+/usr/local/bin/hermes-daemon
+/etc/hermes-daemon/config.toml
+/etc/systemd/system/hermes-daemon.service
+```
+
+It also configures containerd with the `soci` proxy snapshotter, keeps snapshot
+annotations enabled, enables the daemon CRI keychain, and routes kubelet image
+service calls through the daemon so private registry credentials are available
+to lazy layer reads.
+
+## 4. Validate on a Karpenter Node
+
+After a new node joins:
+
+```bash
+kubectl get nodes -l karpenter.sh/nodepool=<nodepool-name> -o wide
+kubectl -n hermes-system logs deploy/hermes-controller
+```
+
+On the EC2 node:
+
+```bash
+sudo systemctl status hermes-daemon.service --no-pager
+sudo ctr plugin ls | grep -E '(^TYPE|soci)'
+sudo grep -n 'proxy_plugins.soci\|snapshotter = "soci"' /etc/containerd/config.toml
+sudo journalctl -u hermes-daemon.service -n 100 --no-pager
+```
+
+Create a policy and a test Pod:
+
+```bash
+kubectl apply -f examples/kubernetes/hermespolicy.yaml
+kubectl run hermes-vllm-trigger \
+  --image=763104351884.dkr.ecr.us-east-1.amazonaws.com/vllm:0.9-gpu-py312-ec2 \
+  --restart=Never \
+  --command -- sleep 300
+```
+
+Expected controller-side signs:
+
+```text
+enqueued image=...
+pulling image=... through containerd API
+built index in-process ...
+ready image=... index=sha256:...
+cleaned source image ...
+```
+
+Expected node-side signs:
+
+```text
+fetching index from Hermes artifact store
+remote snapshot successfully prepared.
+fetching artifact from remote
+```

--- a/hack/eks/install-hermes-daemon.sh
+++ b/hack/eks/install-hermes-daemon.sh
@@ -11,6 +11,7 @@ HERMES_DAEMON_ROOT="${HERMES_DAEMON_ROOT:-/var/lib/hermes-daemon}"
 HERMES_DAEMON_ADDRESS="${HERMES_DAEMON_ADDRESS:-/run/hermes-daemon/hermes-daemon.sock}"
 RESTART_CONTAINERD="${RESTART_CONTAINERD:-true}"
 CONTAINERD_CONFIG="${CONTAINERD_CONFIG:-/etc/containerd/config.toml}"
+KUBELET_ENV_FILE="${KUBELET_ENV_FILE:-/etc/eks/kubelet/environment}"
 
 if [[ "${EUID}" -ne 0 ]]; then
   echo "install-hermes-daemon.sh must run as root. In userData this is already root; manually use: curl ... | sudo -E bash" >&2
@@ -144,6 +145,10 @@ cat >"${HERMES_CONFIG_PATH}" <<EOF_CONFIG
   timeout_sec = 5
   platform = "${HERMES_PLATFORM}"
   fallback_to_registry = true
+
+[cri_keychain]
+  enable_keychain = true
+  image_service_path = "/run/containerd/containerd.sock"
 EOF_CONFIG
 
 cat >/etc/systemd/system/hermes-daemon.service <<EOF_SERVICE
@@ -261,6 +266,73 @@ enable_cri_snapshotter() {
     exit "${rc}"
   }
 
+  set_disable_snapshot_annotations_in_table() {
+    local table_path="$1"
+    local tmp_config="${CONTAINERD_CONFIG}.hermes"
+    local rc
+
+    awk -v table_path="${table_path}" '
+      function normalize(line) {
+        normalized = line
+        gsub(/["\047[:space:]]/, "", normalized)
+        return normalized
+      }
+      function is_section(line) {
+        return line ~ /^[[:space:]]*\[/
+      }
+      function is_target_section(line) {
+        return normalize(line) == "[plugins." table_path "]"
+      }
+      function write_option_if_missing() {
+        if (in_target && !option_written) {
+          print "  disable_snapshot_annotations = false"
+          option_written = 1
+        }
+      }
+      BEGIN {
+        in_target = 0
+        target_seen = 0
+        option_written = 0
+      }
+      is_section($0) {
+        write_option_if_missing()
+        in_target = is_target_section($0)
+        if (in_target) {
+          target_seen = 1
+          option_written = 0
+        }
+        print
+        next
+      }
+      in_target && $0 ~ /^[[:space:]]*disable_snapshot_annotations[[:space:]]*=/ {
+        print "  disable_snapshot_annotations = false"
+        option_written = 1
+        next
+      }
+      {
+        print
+      }
+      END {
+        write_option_if_missing()
+        if (!target_seen) {
+          exit 42
+        }
+      }
+    ' "${CONTAINERD_CONFIG}" >"${tmp_config}" || rc=$?
+
+    if [[ "${rc:-0}" -eq 0 ]]; then
+      mv "${tmp_config}" "${CONTAINERD_CONFIG}"
+      return 0
+    fi
+
+    rm -f "${tmp_config}"
+    if [[ "${rc}" -eq 42 ]]; then
+      return 1
+    fi
+    echo "failed to update containerd snapshot annotation setting in ${table_path}" >&2
+    exit "${rc}"
+  }
+
   remove_legacy_cri_snapshotter_table() {
     local tmp_config="${CONTAINERD_CONFIG}.hermes"
 
@@ -303,6 +375,8 @@ enable_cri_snapshotter() {
 EOF_CRI
   fi
 
+  set_disable_snapshot_annotations_in_table "${table_path}" || true
+
   if grep -q '^\[plugins\."io\.containerd\.cri\.v1\.images"\]' "${CONTAINERD_CONFIG}" &&
     ! grep -q '^\[\[plugins\."io\.containerd\.transfer\.v1\.local"\.unpack_config\]\]' "${CONTAINERD_CONFIG}"; then
     cat >>"${CONTAINERD_CONFIG}" <<EOF_TRANSFER
@@ -314,9 +388,21 @@ EOF_TRANSFER
   fi
 }
 
+enable_kubelet_image_service_proxy() {
+  if [[ ! -f "${KUBELET_ENV_FILE}" ]]; then
+    return 0
+  fi
+  if grep -q -- '--image-service-endpoint=' "${KUBELET_ENV_FILE}"; then
+    return 0
+  fi
+  cp "${KUBELET_ENV_FILE}" "${KUBELET_ENV_FILE}.pre-hermes-$(date +%Y%m%d%H%M%S)"
+  sed -i 's#^NODEADM_KUBELET_ARGS=\(.*\)$#NODEADM_KUBELET_ARGS=\1 --image-service-endpoint=unix://'"${HERMES_DAEMON_ADDRESS}"'#' "${KUBELET_ENV_FILE}"
+}
+
 backup_containerd_config
 ensure_proxy_plugin
 enable_cri_snapshotter
+enable_kubelet_image_service_proxy
 
 systemctl daemon-reload
 systemctl enable --now hermes-daemon.service
@@ -324,6 +410,9 @@ systemctl restart hermes-daemon.service
 
 if [[ "${RESTART_CONTAINERD}" == "true" ]]; then
   systemctl restart containerd
+fi
+if [[ -f "${KUBELET_ENV_FILE}" ]]; then
+  systemctl restart kubelet
 fi
 
 systemctl is-active hermes-daemon.service


### PR DESCRIPTION
## Summary
- enable the daemon CRI keychain so kubelet PullImage auth is available to lazy layer fetches
- keep containerd snapshot annotations enabled for the containerd v2 CRI image plugin
- route EKS kubelet image service calls through hermes-daemon and document quoted presigned URL userData

## Verification
- bash -n hack/eks/install-hermes-daemon.sh
- EKS/Karpenter e2e on cluster-jw with a fresh hermes NodeClaim
- nodeclaim/hermes-9kmsn Ready on ip-10-0-28-65.us-east-2.compute.internal
- pod/default/hermes-vllm-workload-64cd9b5f7f-r7czz Ready on the hermes node
- pod event: pulled 763104351884.dkr.ecr.us-east-1.amazonaws.com/vllm:0.9-gpu-py312-ec2 in 13.029s
- node config verified: [cri_keychain] enabled, kubelet --image-service-endpoint=unix:///run/hermes-daemon/hermes-daemon.sock, containerd snapshotter=soci, disable_snapshot_annotations=false
- hermes-daemon logs showed remote snapshot successfully prepared and fetching artifact from remote; no no basic auth credentials / unable to get image ref errors in the verified window
