### PR TITLE
ci: add pull request build workflow

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -1,0 +1,46 @@
+name: PR Build
+
+on:
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.9"
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends build-essential zlib1g-dev
+
+      - name: Test
+        run: go test ./...
+
+      - name: Build controller
+        run: |
+          mkdir -p bin
+          CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -trimpath -o bin/hermes-controller ./cmd/controller
+
+      - name: Build daemon
+        run: |
+          mkdir -p bin
+          GIT_VERSION="$(git describe --tags --always --dirty)"
+          GIT_COMMIT="$(git rev-parse HEAD)"
+          ldflags="-s -w -linkmode external -extldflags '-static' -X github.com/cloudpilot-ai/hermes/pkg/common/version.Version=${GIT_VERSION} -X github.com/cloudpilot-ai/hermes/pkg/common/version.Revision=${GIT_COMMIT}"
+          CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -trimpath -tags "netgo osusergo" -ldflags "${ldflags}" -o bin/hermes-daemon ./cmd/daemon


### PR DESCRIPTION
## Summary
- add a pull_request GitHub Actions workflow for main
- install Linux build dependencies needed by Hermes CGO/zlib code
- run go test ./..., build the controller binary, and build the linux/amd64 daemon binary

## Validation
- git diff --cached --check
- local linux/amd64 Docker validation installed build-essential, zlib1g-dev, and git, then ran go test ./..., built bin/hermes-controller, and built bin/hermes-daemon

Note: the local container run emitted the usual glibc warning for statically linked binaries that use dlopen; the build completed successfully.