### PR TITLE
fix(deps): bump containerd to v1.7.33 (CVE-2026-53488, CVE-2026-47262)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudpilot-ai/hermes
 go 1.25.0
 
 require (
-	github.com/containerd/containerd v1.7.32
+	github.com/containerd/containerd v1.7.33
 	github.com/containerd/containerd/api v1.8.0
 	github.com/containerd/continuity v0.5.0
 	github.com/containerd/errdefs v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
-github.com/containerd/containerd v1.7.32 h1:S54xuVcPxeLaYgaRABtpJ2VyVUVsy0IGf7qHBs+sbY8=
-github.com/containerd/containerd v1.7.32/go.mod h1:jdwD6s/BhV4XVJGrvtziNPVA+83n66TwptVaPKprq4E=
+github.com/containerd/containerd v1.7.33 h1:iAkYGC/ifR/V+0eR4iXWHNGYUF0DF2PmGV5iz4Irj5M=
+github.com/containerd/containerd v1.7.33/go.mod h1:gSbSCVjPCdkfJCjyrzz7aRC+xFlqVbatNpfHfVCYGUM=
 github.com/containerd/containerd/api v1.8.0 h1:hVTNJKR8fMc/2Tiw60ZRijntNMd1U+JVMyTRdsD2bS0=
 github.com/containerd/containerd/api v1.8.0/go.mod h1:dFv4lt6S20wTu/hMcP4350RL87qPWLVa/OHOwmmdnYc=
 github.com/containerd/continuity v0.5.0 h1:7a85HZpCSs+1Zps0Ee3DPSuAWY+0SJM1JNM51nlEVDg=


### PR DESCRIPTION
## What

Bumps `github.com/containerd/containerd` from **v1.7.32** to **v1.7.33** (a direct dependency). Only `go.mod` / `go.sum` change.

## Why — clears two Dependabot/Vanta findings

| Severity | CVE | Advisory | Issue |
|---|---|---|---|
| **HIGH** | CVE-2026-53488 | GHSA-xhf5-7wjv-pqxp | CRI plugin propagated image-config `LABEL`s to containers without validation → potential arbitrary command execution on the host |
| **MEDIUM** | CVE-2026-47262 | GHSA-jpcc-p29g-p8mq | A maliciously crafted image could exhaust memory and OOM-kill containerd (DoS) |

Both are fixed upstream in containerd 1.7.33.

## Verification

- `go mod verify` → all modules verified
- This is a semver **patch** upgrade within the same minor (API-compatible)
- Full Linux+cgo build runs in CI (the daemon imports Linux-only / cgo packages that cannot be cross-compiled on macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)