### PR TITLE
chore: add grouped Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  # Go modules — proactively keep dependencies fresh so fewer published CVEs
+  # land on stale versions. Bundled into a single weekly PR to reduce noise.
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      go-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  # GitHub Actions used in workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` (the repo had none) enabling **weekly version updates** for:
- **Go modules** (`/`)
- **GitHub Actions** (workflow action versions)

Updates are **grouped** into a single PR per ecosystem.

## Why

These keep dependencies fresh *proactively*, so newly published CVEs are less likely to land on a stale pinned version (which is what forces reactive one-off bump PRs like #16). Grouping keeps the PR count low.

Security updates are unaffected — they continue to arrive as individual, trackable PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)