### PR TITLE
Publish multi-architecture Hermes controller images

### DIFF
--- a/.github/workflows/build-eks-artifacts.yaml
+++ b/.github/workflows/build-eks-artifacts.yaml
@@ -11,9 +11,16 @@ permissions:
   contents: write
 
 jobs:
-  build:
-    name: Build Hermes artifacts
-    runs-on: ubuntu-latest
+  controller-images:
+    name: Build controller (${{ matrix.arch }})
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - uses: actions/checkout@v7
@@ -24,7 +31,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.26.0"
           cache: false
 
       - name: Install build deps
@@ -39,11 +46,6 @@ jobs:
           echo "AWS_DEFAULT_REGION=us-east-2" >> $GITHUB_ENV
           echo "GIT_VERSION=$(git describe --tags --always --dirty)" >> $GITHUB_ENV
           echo "GIT_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
-          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
-            echo "HERMES_RELEASE_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
-          else
-            echo "HERMES_RELEASE_TAG=" >> $GITHUB_ENV
-          fi
 
       - name: AWS CLI Init
         uses: unfor19/install-aws-cli-action@v1
@@ -57,11 +59,65 @@ jobs:
       - name: Build and publish controller image
         run: |
           export KO_DOCKER_REPO=public.ecr.aws/cloudpilotai/hermes-controller
-          ko_tags=(--tags latest)
-          if [[ -n "${HERMES_RELEASE_TAG}" ]]; then
-            ko_tags+=(--tags "${HERMES_RELEASE_TAG}")
+          ko build --bare --platform="linux/${{ matrix.arch }}" github.com/cloudpilot-ai/hermes/cmd/controller --tags "latest-${{ matrix.arch }}"
+
+  controller-index:
+    name: Publish controller image index
+    needs: controller-images
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Config env
+        run: |
+          echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_AK }}" >> $GITHUB_ENV
+          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SK }}" >> $GITHUB_ENV
+          echo "AWS_DEFAULT_REGION=us-east-2" >> $GITHUB_ENV
+
+      - name: AWS CLI Init
+        uses: unfor19/install-aws-cli-action@v1
+
+      - name: Config ECR
+        run: |
+          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/cloudpilotai
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Publish multi-platform index
+        env:
+          IMAGE: public.ecr.aws/cloudpilotai/hermes-controller
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          tags=(--tag "${IMAGE}:latest")
+          if [[ -n "${RELEASE_TAG}" ]]; then
+            tags+=(--tag "${IMAGE}:${RELEASE_TAG}")
           fi
-          ko build --bare github.com/cloudpilot-ai/hermes/cmd/controller "${ko_tags[@]}"
+          docker buildx imagetools create "${tags[@]}" "${IMAGE}:latest-amd64" "${IMAGE}:latest-arm64"
+
+  daemon-artifacts:
+    name: Build Hermes daemon artifacts
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+          fetch-depth: 0
+          submodules: true
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.0"
+          cache: false
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends zlib1g-dev
+
+      - name: Config env
+        run: |
+          echo "GIT_VERSION=$(git describe --tags --always --dirty)" >> $GITHUB_ENV
+          echo "GIT_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       - name: Build daemon binary
         run: |


### PR DESCRIPTION
## Summary

- build the CGO-based controller natively on Linux AMD64 and ARM64 runners
- publish architecture-specific images and combine them into multi-platform latest and release indexes
- align the release workflow with the Go version required by `go.mod`

## Testing

- `actionlint` on the release workflow
- `go test ./...` in a Linux ARM64 container
- static controller builds in Linux AMD64 and ARM64 containers